### PR TITLE
Fix wrong closing tag for preview div

### DIFF
--- a/app/views/editors/simple_markdown.html.erb
+++ b/app/views/editors/simple_markdown.html.erb
@@ -7,5 +7,5 @@
   <textarea id="editor"></textarea>
   <div id="column-resizer"></div>
   <div id="preview">
-  </preview>
+  </div>
 </div>


### PR DESCRIPTION
Noticed that <div id="preview> was closed with the bad tag </preview>