### PR TITLE
Style <code> that are children of <li>

### DIFF
--- a/app/assets/stylesheets/editors/simple_markdown.scss.css
+++ b/app/assets/stylesheets/editors/simple_markdown.scss.css
@@ -105,7 +105,7 @@ blockquote > :last-child {
   margin-bottom: 0;
 }
 
-
+li code,
 p code {
   padding: 2px 4px;
   font-size: 90%;


### PR DESCRIPTION
Code blocks declared in lists weren't being styled properly because the formatting only applied to codes in paragraphs. They didn't apply to codes in lists